### PR TITLE
fix environment variable for bash shell

### DIFF
--- a/tauv_gui/gui_setup.bash
+++ b/tauv_gui/gui_setup.bash
@@ -8,21 +8,21 @@ sudo sh -c "echo 0 >/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts"
 echo Restarting procps
 sudo service procps restart
 
-echo Adjust ROS environment variables in ~/.zshrc
-line='export ROS_HOSTNAME=$HOST.local'
+echo Adjust ROS environment variables in ~/.bashrc
+line='export ROS_HOSTNAME=$HOSTNAME.local'
 file=~/.bashrc
 if ! grep -q -x -F -e "$line" <"$file"; then
   printf '%s\n' "$line" >>"$file"
 fi
 
-line='export ROS_MASTER_URI=http://$HOST.local:11311'
+line='export ROS_MASTER_URI=http://$HOSTNAME.local:11311'
 file=~/.bashrc
 if ! grep -q -x -F -e "$line" <"$file"; then
   printf '%s\n' "$line" >>"$file"
 fi
 
 echo Verifying avahi name resolution: \(should not time out\)
-avahi-resolve-host-name ${HOST}.local
+avahi-resolve-host-name ${HOSTNAME}.local
 
 source ~/.bashrc
 


### PR DESCRIPTION
In zshell the environment variable is $HOST, but in bash it is $HOSTNAME. Fixed the bash version of the gui setup script to reflect this.