### PR TITLE
fix: change thruster curve PWM solving

### DIFF
--- a/src/packages/tauv_common/src/tauv_util/math.py
+++ b/src/packages/tauv_common/src/tauv_util/math.py
@@ -1,0 +1,16 @@
+from math import sqrt
+
+def quadratic_roots(a, b, c):
+    """
+    Quadratic equation root finding
+    :param a: The coefficient of the x^2 term
+    :param b: The coefficient of the x term
+    :param c: The coefficient of the constant term
+    """
+    
+    disc = b ** 2 - 4 * a * c
+    if disc < 0: raise ArithmeticError
+    elif disc == 0:
+        return [(-b + sqrt(disc)) / (2 * a)]
+
+    return [(-b + sqrt(disc)) / (2 * a), (-b - sqrt(disc)) / (2 * a)]

--- a/src/packages/tauv_config/albatross_description/yaml/thrusters.yaml
+++ b/src/packages/tauv_config/albatross_description/yaml/thrusters.yaml
@@ -16,8 +16,8 @@ thrust_inversions: [1, 1, 1, 1, -1, 1, -1, -1]
 # 12 sets of thrust coefficients total: 
 #   6 sets for voltage levels [10, 12, 14, 16, 18, 20] for forward thrust
 #   6 sets for voltage levels [10, 12, 14, 16, 18, 20] for reverse thrust
-# parameters are named as fwd_{X}v_thrust_coefficients
-# parameters are in a, b, c order a(pwm)^2 + b(pwm) + c
+# each direction contains a (voltage level, quadratic coefficients) pair
+# parameters are in a, b, c order for a(pwm)^2 + b(pwm) + c
 
 fwd_thrust_coefficients: {
   "10": [1.16144783e-05 -3.15952327e-02  2.11490226e+01],

--- a/src/packages/tauv_config/albatross_description/yaml/thrusters.yaml
+++ b/src/packages/tauv_config/albatross_description/yaml/thrusters.yaml
@@ -13,6 +13,26 @@ positive_min_thrust: 1
 positive_max_thrust: 60
 thrust_inversions: [1, 1, 1, 1, -1, 1, -1, -1]
 
-# constant, voltage, voltage^2, pwm, pwm^2
-positive_thrust_coefficients: [2.179239e+02, 2.997305e+00, -4.674627e-02, -3.968255e-01, 1.520276e-04]
-negative_thrust_coefficients: [-2.946548e+02, -2.425470e+00, 3.983119e-02, 3.807154e-01, -1.103201e-04]
+# 12 sets of thrust coefficients total: 
+#   6 sets for voltage levels [10, 12, 14, 16, 18, 20] for forward thrust
+#   6 sets for voltage levels [10, 12, 14, 16, 18, 20] for reverse thrust
+# parameters are named as fwd_{X}v_thrust_coefficients
+# parameters are in a, b, c order a(pwm)^2 + b(pwm) + c
+
+fwd_thrust_coefficients: {
+  "10": [1.16144783e-05 -3.15952327e-02  2.11490226e+01],
+  "12": [1.47815669e-05 -4.02962851e-02  2.70604288e+01],
+  "14": [1.80984112e-05 -4.94310799e-02  3.32862079e+01],
+  "16": [2.06423783e-05 -5.61673450e-02  3.76499826e+01],
+  "18": [2.87506426e-05 -8.20550266e-02  5.83067530e+01],
+  "20": [3.78181081e-05 -1.11400271e-01  8.20078160e+01]
+}
+
+rev_thrust_coefficients: [
+  "10": [-8.83590912e-06  2.92128353e-02 -2.38423767e+01],
+  "12": [-1.07079189e-05  3.56604304e-02 -2.92812685e+01],
+  "14": [-1.29181068e-05  4.30525764e-02 -3.53804955e+01],
+  "16": [-1.52230980e-05  5.05389202e-02 -4.14171280e+01],
+  "18": [-1.88937903e-05  6.13312121e-02 -4.93678568e+01],
+  "20": [-2.44892435e-05  7.67425133e-02 -5.99557017e+01]
+]

--- a/src/packages/tauv_config/kingfisher_description/yaml/thrusters.yaml
+++ b/src/packages/tauv_config/kingfisher_description/yaml/thrusters.yaml
@@ -15,8 +15,8 @@ thrust_inversions: [1, 1, 1, 1, -1, 1, -1, 1]
 # 12 sets of thrust coefficients total: 
 #   6 sets for voltage levels [10, 12, 14, 16, 18, 20] for forward thrust
 #   6 sets for voltage levels [10, 12, 14, 16, 18, 20] for reverse thrust
-# parameters are named as fwd_{X}v_thrust_coefficients
-# parameters are in a, b, c order a(pwm)^2 + b(pwm) + c
+# each direction contains a (voltage level, quadratic coefficients) pair
+# parameters are in a, b, c order for a(pwm)^2 + b(pwm) + c
 
 fwd_thrust_coefficients: {
   "10": [1.16144783e-05 -3.15952327e-02  2.11490226e+01],

--- a/src/packages/tauv_config/kingfisher_description/yaml/thrusters.yaml
+++ b/src/packages/tauv_config/kingfisher_description/yaml/thrusters.yaml
@@ -12,6 +12,26 @@ positive_min_thrust: 1
 positive_max_thrust: 60
 thrust_inversions: [1, 1, 1, 1, -1, 1, -1, 1]
 
-# constant, voltage, voltage^2, pwm, pwm^2
-positive_thrust_coefficients: [2.179239e+02, 2.997305e+00, -4.674627e-02, -3.968255e-01, 1.520276e-04]
-negative_thrust_coefficients: [-2.946548e+02, -2.425470e+00, 3.983119e-02, 3.807154e-01, -1.103201e-04]
+# 12 sets of thrust coefficients total: 
+#   6 sets for voltage levels [10, 12, 14, 16, 18, 20] for forward thrust
+#   6 sets for voltage levels [10, 12, 14, 16, 18, 20] for reverse thrust
+# parameters are named as fwd_{X}v_thrust_coefficients
+# parameters are in a, b, c order a(pwm)^2 + b(pwm) + c
+
+fwd_thrust_coefficients: {
+  "10": [1.16144783e-05 -3.15952327e-02  2.11490226e+01],
+  "12": [1.47815669e-05 -4.02962851e-02  2.70604288e+01],
+  "14": [1.80984112e-05 -4.94310799e-02  3.32862079e+01],
+  "16": [2.06423783e-05 -5.61673450e-02  3.76499826e+01],
+  "18": [2.87506426e-05 -8.20550266e-02  5.83067530e+01],
+  "20": [3.78181081e-05 -1.11400271e-01  8.20078160e+01]
+}
+
+rev_thrust_coefficients: [
+  "10": [-8.83590912e-06  2.92128353e-02 -2.38423767e+01],
+  "12": [-1.07079189e-05  3.56604304e-02 -2.92812685e+01],
+  "14": [-1.29181068e-05  4.30525764e-02 -3.53804955e+01],
+  "16": [-1.52230980e-05  5.05389202e-02 -4.14171280e+01],
+  "18": [-1.88937903e-05  6.13312121e-02 -4.93678568e+01],
+  "20": [-2.44892435e-05  7.67425133e-02 -5.99557017e+01]
+]

--- a/src/packages/tauv_vehicle/src/thrusters/thrusters.py
+++ b/src/packages/tauv_vehicle/src/thrusters/thrusters.py
@@ -144,7 +144,6 @@ class Thrusters:
 
             if self._minimum_pwm_speed < target_pwm < self._maximum_pwm_speed:
                 pwm_speed = target_pwm
-            
         except ArithmeticError:
             rospy.logwarn(f"Requested thruster PWMs with no solution (at {thrust} kg F)")
         

--- a/src/packages/tauv_vehicle/src/thrusters/thrusters.py
+++ b/src/packages/tauv_vehicle/src/thrusters/thrusters.py
@@ -126,12 +126,12 @@ class Thrusters:
             return pwm_speed
 
         if thrust < 0 and -self._negative_max_thrust < thrust < -self._negative_min_thrust:
-            lower_quadratic = self._rev_thrust_coefficients[str(lower_v)]
-            upper_quadratic = self._rev_thrust_coefficients[str(upper_v)]
+            lower_quadratic = self._rev_thrust_coefficients[lower_v]
+            upper_quadratic = self._rev_thrust_coefficients[upper_v]
             selector = min
         elif thrust > 0 and self._positive_min_thrust < thrust < self._positive_max_thrust:
-            lower_quadratic = self._fwd_thrust_coefficients[str(lower_v)]
-            upper_quadratic = self._fwd_thrust_coefficients[str(upper_v)]
+            lower_quadratic = self._fwd_thrust_coefficients[lower_v]
+            upper_quadratic = self._fwd_thrust_coefficients[upper_v]
             selector = max
         else:
             return pwm_speed
@@ -161,8 +161,12 @@ class Thrusters:
         self._negative_max_thrust: float = rospy.get_param('~negative_max_thrust')
         self._positive_min_thrust: float = rospy.get_param('~positive_min_thrust')
         self._positive_max_thrust: float = rospy.get_param('~positive_max_thrust')
-        self._fwd_thrust_coefficients: dict[str, List[float]] = np.array(rospy.get_param('~fwd_thrust_coefficients'))
-        self._rev_thrust_coefficients: dict[str, List[float]] = np.array(rospy.get_param('~rev_thrust_coefficients'))
+        self._fwd_thrust_coefficients: dict[int, np.array] = {
+            int(k): np.array(v) for (k, v) in rospy.get_param('~fwd_thrust_coefficients').items()
+        }
+        self._rev_thrust_coefficients: dict[int, np.array] = {
+            int(k): np.array(v) for (k, v) in rospy.get_param('~rev_thrust_coefficients').items()
+        }
         self._thrust_inversions: List[float] = rospy.get_param('~thrust_inversions')
 
 def clamp(x, x_min, x_max):

--- a/src/packages/tauv_vehicle/src/thrusters/thrusters.py
+++ b/src/packages/tauv_vehicle/src/thrusters/thrusters.py
@@ -117,7 +117,6 @@ class Thrusters:
             return ub - 2, ub
 
         pwm_speed = 1500
-
         thrust = thrust * self._thrust_inversions[thruster]
         
         try:
@@ -134,8 +133,8 @@ class Thrusters:
             lower_quadratic = self._fwd_thrust_coefficients[str(lower_v)]
             upper_quadratic = self._fwd_thrust_coefficients[str(upper_v)]
             selector = max
-
-        else: return pwm_speed
+        else:
+            return pwm_speed
 
         scale = (self._battery_voltage - lower_v) / 2.0
         a, b, c = (1 - scale) * lower_quadratic + scale * upper_quadratic
@@ -144,10 +143,12 @@ class Thrusters:
             target_pwm = floor(selector(quadratic_roots(a, b, c - thrust)))
 
             if self._minimum_pwm_speed < target_pwm < self._maximum_pwm_speed:
-                return target_pwm
+                pwm_speed = target_pwm
+            
         except ArithmeticError:
             rospy.logwarn(f"Requested thruster PWMs with no solution (at {thrust} kg F)")
-            return pwm_speed
+        
+        return pwm_speed
 
     def _load_config(self):
         self._maestro_port: str = rospy.get_param('~maestro_port')

--- a/src/packages/tauv_vehicle/src/thrusters/thrusters.py
+++ b/src/packages/tauv_vehicle/src/thrusters/thrusters.py
@@ -1,7 +1,8 @@
 import rospy
 import numpy as np
 from numpy.polynomial.polynomial import Polynomial
-from math import floor
+from math import floor, ceil
+from typing import List
 
 from .maestro import Maestro
 from tauv_util.types import tl
@@ -12,10 +13,9 @@ from geometry_msgs.msg import Wrench, WrenchStamped
 from std_msgs.msg import Bool
 
 from tauv_alarms import Alarm, AlarmClient
-
+from tauv_common.src.tauv_util.math import quadratic_roots
 
 class Thrusters:
-
     def __init__(self):
         self._ac: AlarmClient = AlarmClient()
 
@@ -109,46 +109,50 @@ class Thrusters:
         self._maestro.setTarget(pwm_speed * 4, self._servo_channels[servo])
 
     def _get_pwm_speed(self, thruster: int, thrust: float) -> int:
+        def select_voltage_bounds(v):
+            if v < 10 or v > 20:
+                raise LookupError
+            
+            ub = ceil(v / 2) * 2
+            return ub - 2, ub
+
         pwm_speed = 1500
 
         thrust = thrust * self._thrust_inversions[thruster]
+        
+        try:
+            lower_v, upper_v = select_voltage_bounds(self._battery_voltage)
+        except LookupError:
+            rospy.logwarn(f"Requested thruster PWMs beyond voltage bounds (at {self._battery_voltage}V)")
+            return pwm_speed
 
         if thrust < 0 and -self._negative_max_thrust < thrust < -self._negative_min_thrust:
-            thrust_curve = Polynomial(
-                (self._negative_thrust_coefficients[0]
-                    + self._negative_thrust_coefficients[1] * self._battery_voltage
-                    + self._negative_thrust_coefficients[2] * self._battery_voltage ** 2
-                    - thrust,
-                 self._negative_thrust_coefficients[3],
-                 self._negative_thrust_coefficients[4]),
-            )
-
-            target_pwm_speed = floor(thrust_curve.roots()[0])
-
-            if self._minimum_pwm_speed < target_pwm_speed < self._maximum_pwm_speed:
-                pwm_speed = target_pwm_speed
-
+            lower_quadratic = self._rev_thrust_coefficients[str(lower_v)]
+            upper_quadratic = self._rev_thrust_coefficients[str(upper_v)]
+            selector = min
         elif thrust > 0 and self._positive_min_thrust < thrust < self._positive_max_thrust:
-            thrust_curve = Polynomial(
-                (self._positive_thrust_coefficients[0]
-                    + self._positive_thrust_coefficients[1] * self._battery_voltage
-                    + self._positive_thrust_coefficients[2] * self._battery_voltage ** 2
-                    - thrust,
-                 self._positive_thrust_coefficients[3],
-                 self._positive_thrust_coefficients[4]),
-            )
+            lower_quadratic = self._fwd_thrust_coefficients[str(lower_v)]
+            upper_quadratic = self._fwd_thrust_coefficients[str(upper_v)]
+            selector = max
 
-            target_pwm_speed = floor(thrust_curve.roots()[1])
+        else: return pwm_speed
 
-            if self._minimum_pwm_speed < target_pwm_speed < self._maximum_pwm_speed:
-                pwm_speed = target_pwm_speed
+        scale = (self._battery_voltage - lower_v) / 2.0
+        a, b, c = (1 - scale) * lower_quadratic + scale * upper_quadratic
 
-        return pwm_speed
+        try: 
+            target_pwm = floor(selector(quadratic_roots(a, b, c - thrust)))
+
+            if self._minimum_pwm_speed < target_pwm < self._maximum_pwm_speed:
+                return target_pwm
+        except ArithmeticError:
+            rospy.logwarn(f"Requested thruster PWMs with no solution (at {thrust} kg F)")
+            return pwm_speed
 
     def _load_config(self):
         self._maestro_port: str = rospy.get_param('~maestro_port')
-        self._thruster_channels: [int] = rospy.get_param('~thruster_channels')
-        self._servo_channels: [int] = rospy.get_param('~servo_channels')
+        self._thruster_channels: List[int] = rospy.get_param('~thruster_channels')
+        self._servo_channels: List[int] = rospy.get_param('~servo_channels')
         self._default_battery_voltage: float = rospy.get_param('~default_battery_voltage')
         self._minimum_pwm_speed: float = rospy.get_param('~minimum_pwm_speed')
         self._maximum_pwm_speed: float = rospy.get_param('~maximum_pwm_speed')
@@ -156,9 +160,9 @@ class Thrusters:
         self._negative_max_thrust: float = rospy.get_param('~negative_max_thrust')
         self._positive_min_thrust: float = rospy.get_param('~positive_min_thrust')
         self._positive_max_thrust: float = rospy.get_param('~positive_max_thrust')
-        self._positive_thrust_coefficients: np.array = np.array(rospy.get_param('~positive_thrust_coefficients'))
-        self._negative_thrust_coefficients: np.array = np.array(rospy.get_param('~negative_thrust_coefficients'))
-        self._thrust_inversions: [float] = rospy.get_param('~thrust_inversions')
+        self._fwd_thrust_coefficients: dict[str, List[float]] = np.array(rospy.get_param('~fwd_thrust_coefficients'))
+        self._rev_thrust_coefficients: dict[str, List[float]] = np.array(rospy.get_param('~rev_thrust_coefficients'))
+        self._thrust_inversions: List[float] = rospy.get_param('~thrust_inversions')
 
 def clamp(x, x_min, x_max):
     return min(max(x, x_min), x_max)


### PR DESCRIPTION
Change thruster curve PWM solve method to linear interpolation between quadratic fits of the Blue Robotics thruster data between voltage levels (10, 12, 14, 16, 18, 20)V